### PR TITLE
Development

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -86,14 +86,25 @@ jobs:
         if: steps.check_version.outputs.update_needed == 'true'
         id: calc_hash
         run: |
-          URL="https://github.com/CachyOS/proton-cachyos/releases/download/${{ steps.check_version.outputs.latest_tag }}/proton-cachyos-${{ steps.check_version.outputs.latest_version }}-x86_64_v3.tar.xz"
-          echo "Calculating hash for: $URL"
+          # Calculate hash for v3
+          URL_V3="https://github.com/CachyOS/proton-cachyos/releases/download/${{ steps.check_version.outputs.latest_tag }}/proton-cachyos-${{ steps.check_version.outputs.latest_version }}-x86_64_v3.tar.xz"
+          echo "Calculating hash for v3: $URL_V3"
           
-          HASH=$(nix-prefetch-url --unpack "$URL")
-          SRI_HASH=$(nix hash convert --to sri sha256:$HASH)
-          echo "Hash: $HASH"
-          echo "SRI Hash: $SRI_HASH"
-          echo "sri_hash=$SRI_HASH" >> $GITHUB_OUTPUT
+          HASH_V3=$(nix-prefetch-url --unpack "$URL_V3")
+          SRI_HASH_V3=$(nix hash convert --to sri sha256:$HASH_V3)
+          echo "V3 Hash: $HASH_V3"
+          echo "V3 SRI Hash: $SRI_HASH_V3"
+          echo "sri_hash_v3=$SRI_HASH_V3" >> $GITHUB_OUTPUT
+          
+          # Calculate hash for v4
+          URL_V4="https://github.com/CachyOS/proton-cachyos/releases/download/${{ steps.check_version.outputs.latest_tag }}/proton-cachyos-${{ steps.check_version.outputs.latest_version }}-x86_64_v4.tar.xz"
+          echo "Calculating hash for v4: $URL_V4"
+          
+          HASH_V4=$(nix-prefetch-url --unpack "$URL_V4")
+          SRI_HASH_V4=$(nix hash convert --to sri sha256:$HASH_V4)
+          echo "V4 Hash: $HASH_V4"
+          echo "V4 SRI Hash: $SRI_HASH_V4"
+          echo "sri_hash_v4=$SRI_HASH_V4" >> $GITHUB_OUTPUT
 
       - name: Update default.nix
         if: steps.check_version.outputs.update_needed == 'true'
@@ -101,8 +112,11 @@ jobs:
           # Update version
           sed -i 's/version = ".*";/version = "${{ steps.check_version.outputs.latest_version }}";/' default.nix
           
-          # Update hash (using SRI format) - use | as delimiter to avoid issues with / in hash
-          sed -i 's|hash = ".*";|hash = "${{ steps.calc_hash.outputs.sri_hash }}";|' default.nix
+          # Update v3 hash - find the line with 'then' and replace the hash on that line
+          sed -i '/then "sha256-/s|"sha256-[^"]*"|"${{ steps.calc_hash.outputs.sri_hash_v3 }}"|' default.nix
+          
+          # Update v4 hash - find the line with 'else' and replace the hash on that line
+          sed -i '/else "sha256-/s|"sha256-[^"]*"|"${{ steps.calc_hash.outputs.sri_hash_v4 }}"|' default.nix
 
       - name: Create Pull Request
         if: steps.check_version.outputs.update_needed == 'true'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # CachyOS Proton for Nix
 
-A Nix flake that packages the latest [CachyOS Proton](https://cachyos.org/) compatibility layer for Steam Play.
+> **Note**: This is a personal flake created for experimenting with Nix packaging. Use at your own discretion.
+
+A Nix flake that packages the latest [CachyOS Proton](https://github.com/CachyOS/proton-cachyos) compatibility layer for Steam Play.
+
+## About
+
+This flake uses stable naming conventions so that compatibility tool names in Steam and Lutris remain consistent across updates. Previously, version dates were included in the package names (e.g., `proton-cachyos-10.0-20251107-slr`), which meant you had to manually select the new version in steam settings after each update. Now, the packages are named `proton-cachyos-v3` and `proton-cachyos-v4`, so updates happen seamlessly without requiring manual intervention.
+
+Since CachyOS started compiling Proton for both x86-64-v3 and x86-64-v4 microarchitectures, this flake now provides both variants. Here is what cachy says about V4 "This release includes a x86_64_v4 package. This package is largely untested and experimental.
+It may exhibit issues or completely refuse to work. Use at your own discretion and report issues [here](https://github.com/CachyOS/proton-cachyos/issues/51) only."
 
 ## Features
-
+- V3 and V4 microarchitecture versions available
+- Stable naming that persists across updates
 - Automatically tracks the latest CachyOS Proton releases
 - Daily GitHub Actions workflow to check for updates
 - Simple flake-based installation
@@ -12,13 +22,7 @@ A Nix flake that packages the latest [CachyOS Proton](https://cachyos.org/) comp
 
 ### With Nix Flakes
 
-```bash
-# Test the package
-nix run github:jackgrahn/cachy-proton-nix
-
-# Install to your profile
-nix profile install github:jackgrahn/cachy-proton-nix
-```
+This flake should not be installed as a package directly. Only use it through the appropriate Nix options. A Steam example is shown below.
 
 ### NixOS Configuration
 
@@ -31,32 +35,14 @@ Add to your `flake.nix`:
     cachy-proton.url = "github:jackgrahn/cachy-proton-nix";
   };
 
-  outputs = { self, nixpkgs, cachy-proton, ... }: {
-    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        {
-          programs.steam = {
-            enable = true;
-            extraCompatPackages = [
-              cachy-proton.packages.x86_64-linux.proton-cachyos
-            ];
-          };
-        }
-      ];
-    };
+  programs.steam = {
+    enable = true;
+    extraCompatPackages = [
+      inputs.cachy-proton.packages.x86_64-linux.proton-cachyos-v3
+      inputs.cachy-proton.packages.x86_64-linux.proton-cachyos-v4
+    ];
   };
 }
-```
-
-## Development
-
-```bash
-# Enter development shell
-nix develop
-
-# Build the package
-nix build
 ```
 
 ## Updates

--- a/default.nix
+++ b/default.nix
@@ -2,22 +2,25 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  microarch ? "v3", # Default to v3 for backwards compatibility
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "proton-cachyos";
+  pname = "proton-cachyos-${microarch}";
   version = "10.0-20251107-slr";
 
   src = fetchzip {
-    url = "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-${finalAttrs.version}/proton-cachyos-${finalAttrs.version}-x86_64_v3.tar.xz";
-    hash = "sha256-k/qGx1KMZbOsKH5YEiPWk1NOCXZ/N3t7hP45i2VOVWk=";
+    url = "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-${finalAttrs.version}/proton-cachyos-${finalAttrs.version}-x86_64_${microarch}.tar.xz";
+    hash = if microarch == "v3" 
+      then "sha256-k/qGx1KMZbOsKH5YEiPWk1NOCXZ/N3t7hP45i2VOVWk="
+      else "sha256-RB9JOFm2sx+GyRs/IWvAkcE1v7sjSgouTIMJld26cZQ="; # v4
   };
 
     
   # Use a fixed name in the store path regardless of version
-  name = "proton-cachyos";
+  name = "proton-cachyos-${microarch}";
   
-  # Rebuild trigger: 2025-11-13-v4
+  # Rebuild trigger: 2025-11-14-v1
 
 
   dontUnpack = true;
@@ -43,7 +46,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # Patch compatibilitytool.vdf to use a fixed display name
     substituteInPlace $steamcompattool/compatibilitytool.vdf \
-     --replace-fail "proton-cachyos-${finalAttrs.version}" "proton-cachyos"
+     --replace-fail "proton-cachyos-${finalAttrs.version}-x86_64_${microarch}" "proton-cachyos-${microarch}"
 
 
     runHook postInstall

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
-{ lib
-, stdenvNoCC
-, fetchzip
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -11,6 +12,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     url = "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-${finalAttrs.version}/proton-cachyos-${finalAttrs.version}-x86_64_v3.tar.xz";
     hash = "sha256-k/qGx1KMZbOsKH5YEiPWk1NOCXZ/N3t7hP45i2VOVWk=";
   };
+
+    
+  # Use a fixed name in the store path regardless of version
+  name = "proton-cachyos";
+  
+  # Rebuild trigger: 2025-11-13-v4
+
 
   dontUnpack = true;
   dontConfigure = true;
@@ -23,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    
+
     # Make it impossible to add to an environment. Use programs.steam.extraCompatPackages instead.
     echo "${finalAttrs.pname} should not be installed into environments. Please use programs.steam.extraCompatPackages instead." > $out
 
@@ -32,10 +40,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ln -s $src/* $steamcompattool
     rm $steamcompattool/compatibilitytool.vdf
     cp $src/compatibilitytool.vdf $steamcompattool
-    
+
+    # Patch compatibilitytool.vdf to use a fixed display name
+    substituteInPlace $steamcompattool/compatibilitytool.vdf \
+     --replace-fail "proton-cachyos-${finalAttrs.version}" "proton-cachyos"
+
+
     runHook postInstall
   '';
-
 
   meta = with lib; {
     description = ''

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,13 @@
     in
     {
       packages.${system} = {
-        default = self.packages.${system}.proton-cachyos;
-        proton-cachyos = pkgs.callPackage ./default.nix { };
+        default = self.packages.${system}.proton-cachyos-v3;
+        proton-cachyos-v3 = pkgs.callPackage ./default.nix { 
+          microarch = "v3"; 
+        };
+        proton-cachyos-v4 = pkgs.callPackage ./default.nix { 
+          microarch = "v4"; 
+        };
       };
 
       devShells.${system}.default = pkgs.mkShell {


### PR DESCRIPTION
This pull request updates the packaging and workflow to support both v3 and v4 microarchitecture variants of CachyOS Proton, improves the stability of package naming for easier upgrades, and clarifies usage instructions. The most important changes are grouped below:

**Multi-architecture support and stable naming**

* [`default.nix`](diffhunk://#diff-245563af9e34754739b12b294f3324c1d42c116ace7ce8735e21dfbc82d8e064L1-R25): Refactored to support both v3 and v4 variants via a new `microarch` parameter, with stable package names (`proton-cachyos-v3`, `proton-cachyos-v4`) and store paths, ensuring seamless upgrades in Steam/Lutris without manual selection. Also patches `compatibilitytool.vdf` to use the fixed display name. [[1]](diffhunk://#diff-245563af9e34754739b12b294f3324c1d42c116ace7ce8735e21dfbc82d8e064L1-R25) [[2]](diffhunk://#diff-245563af9e34754739b12b294f3324c1d42c116ace7ce8735e21dfbc82d8e064R47-L39)
* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L18-R24): Updated outputs to expose `proton-cachyos-v3` and `proton-cachyos-v4` packages, setting v3 as the default.

**CI workflow improvements**

* [`.github/workflows/update.yml`](diffhunk://#diff-571e661e1640e6f1f415c087c9a72af346ea9fd4655ff5545e5ad6ea596bab97L89-R119): Enhanced the update workflow to fetch, calculate, and update hashes for both v3 and v4 variants, ensuring both are tracked and updated automatically.

**Documentation updates**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R16): Added details about the new stable naming convention and dual-architecture support, clarified the experimental nature of v4, and updated usage instructions to recommend using the flake via Nix options rather than direct installation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-L59)